### PR TITLE
Pin Werkzeug<3 for Flask-Login compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 A multi-user budget tracker built with Flask. Users can register accounts, log in, and record income or expenses. The dashboard lists recent transactions and provides a form to add more. Data is stored in SQLite by default.
 
 ## Setup
-1. Create a virtual environment and install requirements:
+1. Create a virtual environment and install requirements. The project pins
+   `Werkzeug<3` for compatibility with Flask-Login, so re-run the install
+   command after updating `requirements.txt`:
    ```bash
    python3 -m venv venv
    source venv/bin/activate

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ WTForms==3.1.1
 SQLAlchemy==2.0.15
 Flask-SQLAlchemy==3.0.5
 python-dotenv==1.0.0
+Werkzeug<3


### PR DESCRIPTION
## Summary
- pin Werkzeug<3 in requirements
- note the version requirement in README setup instructions

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685310e24b808329a68cd3ce0e9d70a6