### PR TITLE
Fix date default

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask_login import UserMixin
 from . import db, login_manager
@@ -27,7 +27,7 @@ class Transaction(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     amount = db.Column(db.Float, nullable=False)
     category = db.Column(db.String(64), nullable=False)
-    date = db.Column(db.Date, default=datetime.utcnow)
+    date = db.Column(db.Date, default=date.today)
     description = db.Column(db.String(255))
 
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))


### PR DESCRIPTION
## Summary
- switch `Transaction.date` default from `datetime.utcnow` to `date.today`

## Testing
- `python - <<'PY'
from app import create_app, db
from app.models import Transaction
from datetime import date

app = create_app()
with app.app_context():
    db.drop_all()
    db.create_all()
    t = Transaction(amount=10.0, category='Test')
    db.session.add(t)
    db.session.commit()
    print('Inserted:', t.date, type(t.date))
    assert t.date == date.today(), 'Default date not today'

PY`


------
https://chatgpt.com/codex/tasks/task_e_685310e33d0c832987f94edf9f991343