### PR TITLE
Add account sharing and monthly summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Budget Tracker
 
-A multi-user budget tracker built with Flask. Users can register accounts, log in, and record income or expenses. The dashboard lists recent transactions and provides a form to add more. Data is stored in SQLite by default.
+A multi-user budget tracker built with Flask. Users can register accounts, log in, and record income or expenses. Accounts can be shared with another user and the dashboard shows monthly summaries with category charts. Data is stored in SQLite by default.
 
 ## Setup
 1. Create a virtual environment and install requirements. The project pins

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,8 +18,10 @@ def create_app(config_class=Config):
 
     from .auth import auth_bp
     from .budget import budget_bp
+    from .account import account_bp
     app.register_blueprint(auth_bp)
     app.register_blueprint(budget_bp)
+    app.register_blueprint(account_bp)
 
     with app.app_context():
         db.create_all()

--- a/app/account/__init__.py
+++ b/app/account/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+account_bp = Blueprint('account', __name__, template_folder='templates')
+
+from . import routes  # noqa: E402,F401

--- a/app/account/forms.py
+++ b/app/account/forms.py
@@ -1,0 +1,7 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, SubmitField
+from wtforms.validators import DataRequired
+
+class ShareAccountForm(FlaskForm):
+    username = StringField('Partner Username', validators=[DataRequired()])
+    submit = SubmitField('Share Account')

--- a/app/account/routes.py
+++ b/app/account/routes.py
@@ -1,0 +1,20 @@
+from flask import render_template, redirect, url_for, flash
+from flask_login import login_required, current_user
+
+from . import account_bp
+from .forms import ShareAccountForm
+from ..models import db, User
+
+@account_bp.route('/share', methods=['GET', 'POST'])
+@login_required
+def share_account():
+    form = ShareAccountForm()
+    if form.validate_on_submit():
+        partner = User.query.filter_by(username=form.username.data).first()
+        if partner:
+            current_user.account = partner.account
+            db.session.commit()
+            flash(f'Account shared with {partner.username}.', 'success')
+            return redirect(url_for('budget.dashboard'))
+        flash('User not found.', 'danger')
+    return render_template('account/share.html', form=form)

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -3,14 +3,16 @@ from flask_login import login_user, logout_user, login_required
 
 from . import auth_bp
 from .forms import RegistrationForm, LoginForm
-from ..models import db, User
+from ..models import db, User, Account
 
 
 @auth_bp.route('/register', methods=['GET', 'POST'])
 def register():
     form = RegistrationForm()
     if form.validate_on_submit():
-        user = User(username=form.username.data)
+        account = Account(name=form.username.data)
+        db.session.add(account)
+        user = User(username=form.username.data, account=account)
         user.set_password(form.password.data)
         db.session.add(user)
         db.session.commit()

--- a/app/budget/routes.py
+++ b/app/budget/routes.py
@@ -1,5 +1,6 @@
 from flask import render_template, redirect, url_for
 from flask_login import login_required, current_user
+from datetime import date
 
 from . import budget_bp
 from .forms import TransactionForm
@@ -9,9 +10,23 @@ from ..models import db, Transaction
 @budget_bp.route('/')
 @login_required
 def dashboard():
-    transactions = current_user.transactions.order_by(Transaction.date.desc()).all()
+    transactions = Transaction.query.filter_by(account=current_user.account).order_by(Transaction.date.desc()).all()
     form = TransactionForm()
-    return render_template('budget/dashboard.html', transactions=transactions, form=form)
+    month_start = date.today().replace(day=1)
+    monthly = [tx for tx in transactions if tx.date >= month_start]
+    total_income = sum(tx.amount for tx in monthly if tx.amount > 0)
+    total_expenses = sum(-tx.amount for tx in monthly if tx.amount < 0)
+    category_totals = {}
+    for tx in monthly:
+        category_totals[tx.category] = category_totals.get(tx.category, 0) + tx.amount
+    return render_template(
+        'budget/dashboard.html',
+        transactions=transactions,
+        form=form,
+        total_income=total_income,
+        total_expenses=total_expenses,
+        category_totals=category_totals
+    )
 
 
 @budget_bp.route('/add', methods=['POST'])
@@ -24,7 +39,8 @@ def add_transaction():
             category=form.category.data,
             date=form.date.data,
             description=form.description.data,
-            user=current_user
+            user=current_user,
+            account=current_user.account
         )
         db.session.add(transaction)
         db.session.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -1,13 +1,19 @@
-from datetime import datetime, date
+from datetime import date
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask_login import UserMixin
 from . import db, login_manager
 
+class Account(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(64), unique=True, nullable=False)
+    users = db.relationship('User', backref='account', lazy=True)
+    transactions = db.relationship('Transaction', backref='account', lazy=True)
 
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(64), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
+    account_id = db.Column(db.Integer, db.ForeignKey('account.id'), nullable=False)
 
     transactions = db.relationship('Transaction', backref='user', lazy='dynamic')
 
@@ -17,11 +23,9 @@ class User(UserMixin, db.Model):
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)
 
-
 @login_manager.user_loader
 def load_user(user_id):
     return User.query.get(int(user_id))
-
 
 class Transaction(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -31,3 +35,4 @@ class Transaction(db.Model):
     description = db.Column(db.String(255))
 
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    account_id = db.Column(db.Integer, db.ForeignKey('account.id'), nullable=False)

--- a/app/templates/account/share.html
+++ b/app/templates/account/share.html
@@ -1,0 +1,12 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Share Account</h2>
+<form method="post">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">
+        {{ form.username.label(class="form-label") }}
+        {{ form.username(class="form-control") }}
+    </div>
+    {{ form.submit(class="btn btn-primary") }}
+</form>
+{% endblock %}

--- a/app/templates/budget/dashboard.html
+++ b/app/templates/budget/dashboard.html
@@ -1,6 +1,17 @@
 {% extends 'layout.html' %}
 {% block content %}
 <h2>Dashboard</h2>
+<div class="row mb-4">
+    <div class="col-md-6">
+        <div class="alert alert-success">Income: {{ total_income|round(2) }}</div>
+    </div>
+    <div class="col-md-6">
+        <div class="alert alert-danger">Expenses: {{ total_expenses|round(2) }}</div>
+    </div>
+</div>
+<div class="mb-4">
+    <canvas id="catChart" height="100"></canvas>
+</div>
 <form method="post" action="{{ url_for('budget.add_transaction') }}" class="mb-4">
     {{ form.hidden_tag() }}
     <div class="row g-2">
@@ -29,4 +40,17 @@
         {% endfor %}
     </tbody>
 </table>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.3.0/dist/chart.umd.min.js"></script>
+<script>
+const ctx = document.getElementById('catChart');
+const data = {
+    labels: {{ category_totals.keys()|list|tojson }},
+    datasets: [{
+        label: 'Amount',
+        data: {{ category_totals.values()|list|tojson }},
+        backgroundColor: 'rgba(75, 192, 192, 0.5)'
+    }]
+};
+new Chart(ctx, {type: 'bar', data: data});
+</script>
 {% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -14,6 +14,9 @@
             <ul class="navbar-nav ms-auto">
                 {% if current_user.is_authenticated %}
                     <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('account.share_account') }}">Share Account</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>
                     </li>
                 {% else %}


### PR DESCRIPTION
## Summary
- introduce Account model for shared accounts
- create account blueprint with share feature
- show monthly income/expense totals and category charts
- link to share page in the navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68531a54efb483298d510b7fc69a3ccf