### PR TITLE
Add bank integration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,17 @@ A multi-user budget tracker built with Flask. Users can register accounts, log i
 A default development database `app.db` will be created on first run.
 If you have an older copy of `app.db` from a previous version of the app,
 remove it so that the new account-sharing tables can be created automatically.
+
+### Bank integration
+
+The optional bank sync feature uses the Plaid API. Set the following
+environment variables before running the app:
+
+```
+PLAID_CLIENT_ID=your_client_id
+PLAID_SECRET=your_secret
+PLAID_ENV=sandbox  # or development/production
+```
+
+After configuring these values and installing `plaid-python`, a button on the
+dashboard allows syncing transactions from your linked bank account.

--- a/app/bank_integration/__init__.py
+++ b/app/bank_integration/__init__.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+from plaid import ApiClient, Configuration, Environment
+from plaid.api import plaid_api
+from plaid.model.transactions_get_request import TransactionsGetRequest
+from plaid.model.transactions_get_request_options import TransactionsGetRequestOptions
+
+from ..config import Config
+from ..models import Transaction
+
+
+def _create_client():
+    configuration = Configuration(
+        host=getattr(Environment, Config.PLAID_ENV.capitalize()),
+        api_key={
+            "PLAID-CLIENT-ID": Config.PLAID_CLIENT_ID,
+            "PLAID-SECRET": Config.PLAID_SECRET,
+        },
+    )
+    api_client = ApiClient(configuration)
+    return plaid_api.PlaidApi(api_client)
+
+
+client = _create_client()
+
+
+def fetch_transactions(account_id, start_date, end_date):
+    """Fetch transactions for an account and return ``Transaction`` objects."""
+    request = TransactionsGetRequest(
+        access_token=account_id,
+        start_date=start_date,
+        end_date=end_date,
+        options=TransactionsGetRequestOptions(),
+    )
+    response = client.transactions_get(request)
+    transactions = []
+    for item in response['transactions']:
+        tx = Transaction(
+            amount=item['amount'],
+            category=item['category'][0] if item.get('category') else 'Other',
+            date=datetime.strptime(item['date'], '%Y-%m-%d').date(),
+            description=item.get('name', ''),
+        )
+        transactions.append(tx)
+    return transactions

--- a/app/budget/forms.py
+++ b/app/budget/forms.py
@@ -9,3 +9,8 @@ class TransactionForm(FlaskForm):
     date = DateField('Date', validators=[DataRequired()])
     description = StringField('Description')
     submit = SubmitField('Add')
+
+
+class SyncTransactionsForm(FlaskForm):
+    """Simple form with a single submit button to sync bank data."""
+    submit = SubmitField('Sync Bank Transactions')

--- a/app/config.py
+++ b/app/config.py
@@ -7,3 +7,8 @@ class Config:
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, '..', 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    # Plaid API configuration for bank integration
+    PLAID_CLIENT_ID = os.environ.get('PLAID_CLIENT_ID')
+    PLAID_SECRET = os.environ.get('PLAID_SECRET')
+    PLAID_ENV = os.environ.get('PLAID_ENV', 'sandbox')

--- a/app/templates/budget/dashboard.html
+++ b/app/templates/budget/dashboard.html
@@ -23,6 +23,11 @@
     </div>
 </form>
 
+<form method="post" action="{{ url_for('budget.sync_bank') }}" class="mb-4">
+    {{ sync_form.hidden_tag() }}
+    {{ sync_form.submit(class="btn btn-secondary") }}
+</form>
+
 <table class="table table-striped">
     <thead>
         <tr><th>Date</th><th>Category</th><th>Description</th><th class="text-end">Amount</th></tr>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ SQLAlchemy==2.0.15
 Flask-SQLAlchemy==3.0.5
 python-dotenv==1.0.0
 Werkzeug<3
+plaid-python==34.0.0


### PR DESCRIPTION
## Summary
- create `bank_integration` package for Plaid API use
- configure Plaid keys in `Config`
- add sync form and route to dashboard
- update dashboard template with sync button
- document Plaid setup and add dependency
- fix environment host selection and rename fetch helper parameter

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6853232dad348329a1a5fd9254240cb2